### PR TITLE
Support cron format & multiple registries at once

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,14 +23,5 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
-    - name: Format
-      run: make lint
-
-    - name: Vet
-      run: make vet
-
-    - name: Test
-      run: make test
-
     - name: Build
       run: make build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,5 @@ jobs:
       with:
         go-version: 1.17
 
-    - run: echo $GO_FLAGS
-
     - name: Build
-      run: make build
+      run: GOFLAGS="-mod=mod" make build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         go-version: 1.17
 
+    - run: echo $GO_FLAGS
+
     - name: Build
       run: make build
-    - run: echo $GO_FLAGS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,15 +13,11 @@ jobs:
       GOPROXY: "off"
 
     steps:
-
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: 1.17
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
 
     - name: Build
       run: make build
+    - run: echo $GO_FLAGS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,7 @@ jobs:
       with:
         go-version: 1.17
 
+    - run: go env
+
     - name: Build
       run: GOFLAGS="-mod=mod" make build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,4 +21,4 @@ jobs:
     - run: go env
 
     - name: Build
-      run: GOFLAGS="-mod=mod" make build
+      run: GOFLAGS="-mod=mod" GOPROXY="https://proxy.golang.org,direct" make build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 name-ddns
+cov.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .env
-bin/
+name-ddns

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
+# -----------------------------------------------------------------------------
+# The base image for building the binary
+
 FROM golang:1.17-buster AS build
 
 WORKDIR /app
 
-COPY go.mod ./
-#COPY go.sum ./
-RUN go mod download
+COPY go.mod go.sum Makefile ./
+COPY internal internal
+COPY cmd cmd
+RUN BUILD_PATH=/ make build
 
-COPY . .
-
-RUN go build -o /name-ddns ./cmd/ddns
-
+# -----------------------------------------------------------------------------
+# Build the final Docker image
 
 FROM debian:bullseye-slim
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update \
+	&& apt-get install -y ca-certificates \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /name-ddns /bin/name-ddns
 

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,43 @@
 GO_FLAGS   ?=
-BUIL_PATH  ?= "./"
+BUILD_PATH ?= "./"
 NAME       := name-ddns
-OUTPUT_BIN ?= ${BUIL_PATH}${NAME}
+OUTPUT_BIN ?= ${BUILD_PATH}${NAME}
 VERSION    ?= v0.1.0
 IMG_NAME   := naxhh/name-ddns
 IMAGE      := ${IMG_NAME}:${VERSION}
+IMAGE_M1   := ${IMAGE}-arm64
 
 default: help
 
 fmt: ## Formats all files
 	@go fmt ./...
 
-test:   ## Run all tests
+test: ## Run all tests
 	@go clean --testcache && go test ./...
 
-cover:  ## Run test coverage suite
+cover: ## Run test coverage suite
 	@go test ./... --coverprofile=cov.out
 	@go tool cover --html=cov.out
 
-build:  ## Builds the CLI
+build: ## Builds the CLI
 	@go build ${GO_FLAGS} \
 	-o ${OUTPUT_BIN} \
 	./cmd/ddns
 
-img:    ## Build Docker Image
-	@docker build --rm -t ${IMAGE} .
+docker: ## Build Docker Image
+	@docker build \
+	--platform=linux/amd64 \
+	--rm -t ${IMAGE} .
+
+	@docker build \
+	--platform=linux/arm64 \
+	--rm -t ${IMAGE_M1} .
+
+publish: ## Publishes docker images
+	@docker tag ${IMAGE} ${IMG_NAME}:latest
+	@docker push ${IMG_NAME}:latest
+	@docker push ${IMAGE}
+	@docker push ${IMAGE_M1}
 
 help: ## Displays this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":[^:]*?## "}; {printf "\033[38;5;69m%-30s\033[38;5;38m %s\033[0m\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+GO_FLAGS   ?=
+BUIL_PATH  ?= "./"
+NAME       := name-ddns
+OUTPUT_BIN ?= ${BUIL_PATH}${NAME}
+VERSION    ?= v0.1.0
+IMG_NAME   := naxhh/name-ddns
+IMAGE      := ${IMG_NAME}:${VERSION}
+
+default: help
+
+fmt: ## Formats all files
+	@go fmt ./...
+
+test:   ## Run all tests
+	@go clean --testcache && go test ./...
+
+cover:  ## Run test coverage suite
+	@go test ./... --coverprofile=cov.out
+	@go tool cover --html=cov.out
+
+build:  ## Builds the CLI
+	@go build ${GO_FLAGS} \
+	-o ${OUTPUT_BIN} \
+	./cmd/ddns
+
+img:    ## Build Docker Image
+	@docker build --rm -t ${IMAGE} .
+
+help: ## Displays this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":[^:]*?## "}; {printf "\033[38;5;69m%-30s\033[38;5;38m %s\033[0m\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Second example runs every 5 minutes using cron format and configures an A record
 You can create a name.com token in https://www.name.com/account/settings/api
 Supported cron formats defined at https://pkg.go.dev/github.com/robfig/cron
 
+## Docker images
+
+Images are provided on `amd64` by default.
+But versions will be also pushed with a suffix of `-arm64` for arm architecture (read M1 laptops)
+
+Prefer using version tags instead of `latest`
+
 ## Dev
 
 Name.com api docs are in https://www.name.com/api-docs/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Dynamic DNS for Name.com using v4 name.com API
 		-e "NAME_DDNS_TOKEN=namecom-token" \
 		-e "NAME_DDNS_DOMAIN=example.com" \
 		-e "NAME_DDNS_HOST=subdomain" \
-		-e "NAME_DDNS_UPDATE_EVERY_MINUTES=10" \
+		-e "NAME_DDNS_UPDATE_EVERY=@every 10m" \
 		-e "TZ=Europe/London" \
 		naxhh/name-ddns
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,27 @@ Dynamic DNS for Name.com using v4 name.com API
 	docker run --rm \
 		-e "NAME_DDNS_USER=namecom-user" \
 		-e "NAME_DDNS_TOKEN=namecom-token" \
-		-e "NAME_DDNS_DOMAIN=example.com" \
-		-e "NAME_DDNS_HOST=subdomain" \
-		-e "NAME_DDNS_UPDATE_EVERY=@every 10m" \
+
+		-e "NAME_DDNS_CRON_0=@every 10m"
+		-e "NAME_DDNS_DOMAIN_0=example.com" \
+		-e "NAME_DDNS_HOST_0=subdomain" \
+
+		-e "NAME_DDNS_CRON_1=* */5 * * * *"
+		-e "NAME_DDNS_DOMAIN_1=example.com" \
+		-e "NAME_DDNS_HOST_1=subdomain2" \
+		-e "NAME_DDNS_TOKEN_1=other-namecom-token" \
+
 		-e "TZ=Europe/London" \
 		naxhh/name-ddns
 
-This example will create and keep updated an A record on `subdomain.example.com.` pointing to the public IP of the network where the process is running on.
+First example will create and keep updated an A record on `subdomain.example.com.` pointing to the public IP of the network where the process is running on. This will happen every 10 minutes.
+
+Second example runs every 5 minutes using cron format and configures an A record on `subdomain.example.com.` but uses a different API token for that particualr entry.
 
 You can create a name.com token in https://www.name.com/account/settings/api
+Supported cron formats defined at https://pkg.go.dev/github.com/robfig/cron
 
 ## Dev
 
 Name.com api docs are in https://www.name.com/api-docs/
+Cron library https://github.com/robfig/cron

--- a/cmd/ddns/main.go
+++ b/cmd/ddns/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"log"
 	"github.com/naxhh/name-ddns/internal/name"
 	"github.com/naxhh/name-ddns/internal/system"
+	"log"
 	"os"
 )
 

--- a/cmd/ddns/main.go
+++ b/cmd/ddns/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"github.com/naxhh/name-ddns/internal/name"
 	"github.com/naxhh/name-ddns/internal/system"
 	"os"
@@ -12,7 +12,7 @@ func main() {
 	config := name.NewConfig(stopChannel)
 
 	if err := config.Validate(); err != nil {
-		fmt.Println(err)
+		log.Println(err)
 		os.Exit(1)
 	}
 
@@ -20,5 +20,5 @@ func main() {
 
 	app.Run()
 
-	fmt.Println("Shuting down")
+	log.Println("Shuting down")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/naxhh/name-ddns
 
 go 1.17
+
+require github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=

--- a/internal/name/api.go
+++ b/internal/name/api.go
@@ -15,7 +15,7 @@ const (
 	updateRecords        = "https://api.name.com/v4/domains/%s/records/%d"
 )
 
-type api struct {}
+type api struct{}
 
 func newApi() *api {
 	return &api{}
@@ -59,7 +59,7 @@ func (a *api) update(task Task, ip string) error {
 
 	if record == nil {
 		log.Println(fmt.Sprintf("No record found. Creating a new record %s.%s", task.Host, task.Domain))
-		err = a.createRecord(task ,ip)
+		err = a.createRecord(task, ip)
 	} else {
 		log.Println(fmt.Sprintf("Updating record %s.%s", record.Host, task.Domain))
 		err = a.updateRecord(task, record, ip)
@@ -146,7 +146,7 @@ func (a *api) updateRecord(task Task, record *Record, ip string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/internal/name/api.go
+++ b/internal/name/api.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"time"
 )
 
 const (
@@ -66,10 +65,12 @@ func (a *api) update(ip string) error {
 		log.Println(fmt.Sprintf("No record found. Creating a new record %s.%s", a.config.Host, a.config.Domain))
 		err = a.createRecord(ip)
 	} else {
+		/*
 		now := time.Now()
 		nextUpdateAt := now.Add(a.config.UpdateEvery)
 		log.Println(fmt.Sprintf("Updating record %s.%s", record.Host, a.config.Domain))
 		log.Println(fmt.Sprintf("Will update again at %02d:%02d:%02d", nextUpdateAt.Hour(), nextUpdateAt.Minute(), nextUpdateAt.Second()))
+		*/
 		err = a.updateRecord(record, ip)
 	}
 

--- a/internal/name/config.go
+++ b/internal/name/config.go
@@ -2,15 +2,13 @@ package name
 
 import (
 	"os"
-	"strconv"
-	"time"
 )
 
 type Config struct {
 	User  string
 	Token string
 
-	UpdateEvery time.Duration
+	UpdateEveryCronFormat string
 	StopChannel chan struct{}
 
 	Domain string
@@ -18,17 +16,13 @@ type Config struct {
 }
 
 func NewConfig(stopChannel chan struct{}) *Config {
-	updateMinutes, err := strconv.ParseInt(os.Getenv("NAME_DDNS_UPDATE_EVERY_MINUTES"), 10, 0)
-
-	if err != nil {
-		updateMinutes = 30
-	}
+	cronUpdateTime := os.Getenv("NAME_DDNS_UPDATE_EVERY")
 
 	return &Config{
 		User:  os.Getenv("NAME_DDNS_USER"),
 		Token: os.Getenv("NAME_DDNS_TOKEN"),
 
-		UpdateEvery: time.Duration(updateMinutes) * time.Minute,
+		UpdateEveryCronFormat: cronUpdateTime,
 		StopChannel: stopChannel,
 
 		Domain: os.Getenv("NAME_DDNS_DOMAIN"),

--- a/internal/name/config.go
+++ b/internal/name/config.go
@@ -1,25 +1,25 @@
 package name
 
 import (
-	"os"
+	"errors"
 	"fmt"
 	"log"
-	"errors"
+	"os"
 )
 
 type Task struct {
 	CronExpression string
 
-	User string
+	User  string
 	Token string
 
 	Domain string
-	Host string
+	Host   string
 }
 
 type Config struct {
 	StopChannel chan struct{}
-	Tasks []Task
+	Tasks       []Task
 }
 
 func NewConfig(stopChannel chan struct{}) *Config {
@@ -52,19 +52,18 @@ func NewConfig(stopChannel chan struct{}) *Config {
 
 		tasks = append(tasks, Task{
 			CronExpression: cron,
-			User:  user,
-			Token: token,
-			Domain: domain,
-			Host:   host,
+			User:           user,
+			Token:          token,
+			Domain:         domain,
+			Host:           host,
 		})
-
 
 		i++
 	}
 
 	return &Config{
 		StopChannel: stopChannel,
-		Tasks: tasks,
+		Tasks:       tasks,
 	}
 }
 

--- a/internal/name/config.go
+++ b/internal/name/config.go
@@ -2,35 +2,99 @@ package name
 
 import (
 	"os"
+	"fmt"
+	"log"
+	"errors"
 )
 
-type Config struct {
-	User  string
+type Task struct {
+	CronExpression string
+
+	User string
 	Token string
 
-	UpdateEveryCronFormat string
-	StopChannel chan struct{}
-
 	Domain string
-	Host   string
+	Host string
+}
+
+type Config struct {
+	StopChannel chan struct{}
+	Tasks []Task
 }
 
 func NewConfig(stopChannel chan struct{}) *Config {
-	cronUpdateTime := os.Getenv("NAME_DDNS_UPDATE_EVERY")
+	defaultUser := os.Getenv("NAME_DDNS_USER")
+	defaultToken := os.Getenv("NAME_DDNS_TOKEN")
+
+	var tasks []Task
+
+	i := 0
+	for {
+		domain := os.Getenv(fmt.Sprintf("NAME_DDNS_DOMAIN_%d", i))
+
+		if domain == "" {
+			break
+		}
+
+		cron := os.Getenv(fmt.Sprintf("NAME_DDNS_CRON_%d", i))
+		host := os.Getenv(fmt.Sprintf("NAME_DDNS_HOST_%d", i))
+
+		user := os.Getenv(fmt.Sprintf("NAME_DDNS_USER_%d", i))
+		token := os.Getenv(fmt.Sprintf("NAME_DDNS_TOKEN_%d", i))
+
+		if user == "" {
+			user = defaultUser
+		}
+
+		if token == "" {
+			token = defaultToken
+		}
+
+		tasks = append(tasks, Task{
+			CronExpression: cron,
+			User:  user,
+			Token: token,
+			Domain: domain,
+			Host:   host,
+		})
+
+
+		i++
+	}
 
 	return &Config{
-		User:  os.Getenv("NAME_DDNS_USER"),
-		Token: os.Getenv("NAME_DDNS_TOKEN"),
-
-		UpdateEveryCronFormat: cronUpdateTime,
 		StopChannel: stopChannel,
-
-		Domain: os.Getenv("NAME_DDNS_DOMAIN"),
-		Host:   os.Getenv("NAME_DDNS_HOST"),
+		Tasks: tasks,
 	}
 }
 
-func (c *Config) Validate() *error {
-	// TODO: validate config
+func (c *Config) Validate() error {
+	if len(c.Tasks) == 0 {
+		return errors.New("No entries configured, closing")
+	} else {
+		log.Println(fmt.Sprintf("Validating %d entries", len(c.Tasks)))
+	}
+
+	for key, task := range c.Tasks {
+		if task.CronExpression == "" {
+			return errors.New(fmt.Sprintf("Cron expression was empty on entry %d", key))
+		}
+
+		if task.User == "" {
+			return errors.New(fmt.Sprintf("User was empty on entry %d", key))
+		}
+
+		if task.Token == "" {
+			return errors.New(fmt.Sprintf("Token was empty on entry %d", key))
+		}
+
+		if task.Domain == "" {
+			return errors.New(fmt.Sprintf("Domain was empty on entry %d", key))
+		}
+
+		if task.Host == "" {
+			return errors.New(fmt.Sprintf("Host was empty on entry %d", key))
+		}
+	}
 	return nil
 }

--- a/internal/name/poller.go
+++ b/internal/name/poller.go
@@ -1,9 +1,9 @@
 package name
 
 import (
-	"log"
 	"fmt"
 	"github.com/robfig/cron/v3"
+	"log"
 )
 
 type poller struct {


### PR DESCRIPTION
Based on the request at #3.

Add support for cron format.
This stills allows simple configs using "@every 1h" format.

Also this provides support to define multiple A registers at once from the same machine.

Validate the config so we are sure all properties are correct before starting

Finally provide a makefile for easier deveolpment

This Pr has been tagged as v0.1.0 on docker hub and also updated latest with it.
I had also pushed a v0.0.0 with the previous version